### PR TITLE
Added more precise OS metrics

### DIFF
--- a/changelog/unreleased/000031-os-metric.yml
+++ b/changelog/unreleased/000031-os-metric.yml
@@ -1,0 +1,10 @@
+title: Added more precise OS metrics
+authors:
+  - name: Mateusz Witkowski
+    nick: witx98
+    url: https://github.com/witx98
+type: added #[added/changed/deprecated/removed/fixed/security/other]
+issues:
+  - 31
+merge_requests:
+  - 52

--- a/hofund-core/pom.xml
+++ b/hofund-core/pom.xml
@@ -32,6 +32,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.oshi</groupId>
+            <artifactId>oshi-core</artifactId>
+            <version>${oshi-core.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
             <version>${mockwebserver.version}</version>

--- a/hofund-core/src/main/java/dev/logchange/hofund/java/HofundJavaInfoMeter.java
+++ b/hofund-core/src/main/java/dev/logchange/hofund/java/HofundJavaInfoMeter.java
@@ -1,12 +1,10 @@
 package dev.logchange.hofund.java;
 
-import dev.logchange.hofund.os.HofundOsInfo;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.MeterBinder;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;

--- a/hofund-core/src/main/java/dev/logchange/hofund/os/HofundOsInfo.java
+++ b/hofund-core/src/main/java/dev/logchange/hofund/os/HofundOsInfo.java
@@ -4,6 +4,8 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import oshi.SystemInfo;
+import oshi.software.os.OperatingSystem;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
@@ -11,19 +13,19 @@ import lombok.Getter;
 public class HofundOsInfo {
 
     private final String name;
-
     private final String version;
-
     private final String arch;
+    private final String manufacturer;
 
     public static HofundOsInfo get() {
-        String name = System.getProperty("os.name");
-        String version = System.getProperty("os.version");
         String arch = System.getProperty("os.arch");
+        SystemInfo systemInfo = new SystemInfo();
+        OperatingSystem os = systemInfo.getOperatingSystem();
         return HofundOsInfo.builder()
-                .name(name)
-                .version(version)
+                .name(os.getFamily())
+                .version(os.getVersionInfo().toString())
                 .arch(arch)
+                .manufacturer(os.getManufacturer())
                 .build();
     }
 

--- a/hofund-core/src/main/java/dev/logchange/hofund/os/HofundOsInfoMeter.java
+++ b/hofund-core/src/main/java/dev/logchange/hofund/os/HofundOsInfoMeter.java
@@ -34,6 +34,7 @@ public class HofundOsInfoMeter implements MeterBinder {
         List<Tag> tags = new LinkedList<>();
 
         tags.add(Tag.of("name", info.getName()));
+        tags.add(Tag.of("manufacturer", info.getManufacturer()));
         tags.add(Tag.of("version", info.getVersion()));
         tags.add(Tag.of("arch", info.getArch()));
 

--- a/hofund-spring-boot-e2e/src/test/java/dev/logchange/hofund/os/HofundOsInfoE2ETest.java
+++ b/hofund-spring-boot-e2e/src/test/java/dev/logchange/hofund/os/HofundOsInfoE2ETest.java
@@ -8,6 +8,8 @@ import org.springframework.boot.test.autoconfigure.actuate.observability.AutoCon
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import oshi.SystemInfo;
+import oshi.software.os.OperatingSystem;
 
 @Slf4j
 @AutoConfigureObservability
@@ -24,16 +26,20 @@ public class HofundOsInfoE2ETest {
         //given:
         String path = "http://localhost:" + port + "/actuator/prometheus";
 
-        String name = System.getProperty("os.name");
-        String version = System.getProperty("os.version");
+        OperatingSystem os = new SystemInfo().getOperatingSystem();
+
+        String name = os.getFamily();
+        String manufacturer = os.getManufacturer();
+        String version = os.getVersionInfo().toString();
         String arch = System.getProperty("os.arch");
 
         String expected =
                 "# HELP hofund_os_info Basic information about operating system that is running this application\n" +
                 "# TYPE hofund_os_info gauge\n" +
-                "hofund_os_info{arch=\"{arch}\",name=\"{name}\",version=\"{version}\"} 1"
+                "hofund_os_info{arch=\"{arch}\",manufacturer=\"{manufacturer}\",name=\"{name}\",version=\"{version}\"} 1"
                 .replace("{arch}", arch)
                 .replace("{name}", name)
+                .replace("{manufacturer}", manufacturer)
                 .replace("{version}", version);
 
         //when:

--- a/hofund-spring-boot-starter/pom.xml
+++ b/hofund-spring-boot-starter/pom.xml
@@ -34,6 +34,12 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.github.oshi</groupId>
+            <artifactId>oshi-core</artifactId>
+            <version>${oshi-core.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <spring-boot.version>3.3.1</spring-boot.version>
+        <oshi-core.version>6.6.5</oshi-core.version>
 
         <!-- TESTS -->
         <mockwebserver.version>4.12.0</mockwebserver.version>


### PR DESCRIPTION
## Issue: https://github.com/logchange/hofund/issues/31

## Result:
```
# HELP hofund_os_info Basic information about operating system that is running this application
# TYPE hofund_os_info gauge
hofund_os_info{arch="amd64",manufacturer="Microsoft",name="Windows",version="10 (Home) build 19045"} 1
```