### PR TITLE
Added H2 datasource type

### DIFF
--- a/changelog/unreleased/000001-h2-connection.yml
+++ b/changelog/unreleased/000001-h2-connection.yml
@@ -1,0 +1,12 @@
+# This file is used by logchange tool to generate CHANGELOG.md 🌳 🪓 => 🪵 
+# Visit https://github.com/logchange/logchange and leave a star 🌟 
+# More info about configuration you can find https://github.com/logchange/logchange#yaml-format ⬅️⬅ ️
+title: Added support for H2 datasource type
+authors:
+  - name: Mateusz Witkowski
+    nick: witx98
+    url: https://github.com/witx98
+merge_requests:
+  - 56
+type: added
+

--- a/hofund-spring/src/main/java/dev/logchange/hofund/connection/spring/datasource/DataSourceConnectionFactory.java
+++ b/hofund-spring/src/main/java/dev/logchange/hofund/connection/spring/datasource/DataSourceConnectionFactory.java
@@ -1,6 +1,7 @@
 package dev.logchange.hofund.connection.spring.datasource;
 
 import dev.logchange.hofund.connection.HofundDatabaseConnection;
+import dev.logchange.hofund.connection.spring.datasource.h2.H2Connection;
 import dev.logchange.hofund.connection.spring.datasource.oracle.OracleConnection;
 import dev.logchange.hofund.connection.spring.datasource.postgresql.PostgreSQLConnection;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +23,7 @@ public class DataSourceConnectionFactory {
             return switch (dbType) {
                 case POSTGRESQL -> new PostgreSQLConnection(metaData, dataSource).toHofundConnection();
                 case ORACLE -> new OracleConnection(metaData, dataSource).toHofundConnection();
+                case H2 -> new H2Connection(metaData, dataSource).toHofundConnection();
                 default -> {
                     log.warn("Currently there is no support for DataSource: {} please create issue at: https://github.com/logchange/hofund", productName);
                     yield null;

--- a/hofund-spring/src/main/java/dev/logchange/hofund/connection/spring/datasource/DatabaseProductName.java
+++ b/hofund-spring/src/main/java/dev/logchange/hofund/connection/spring/datasource/DatabaseProductName.java
@@ -10,6 +10,7 @@ import java.util.stream.Stream;
 public enum DatabaseProductName {
     POSTGRESQL("PostgreSQL"),
     ORACLE("Oracle"),
+    H2("H2"),
     NOT_RECOGNIZED("Not recognized");
 
     private final String name;

--- a/hofund-spring/src/main/java/dev/logchange/hofund/connection/spring/datasource/h2/H2Connection.java
+++ b/hofund-spring/src/main/java/dev/logchange/hofund/connection/spring/datasource/h2/H2Connection.java
@@ -1,0 +1,55 @@
+package dev.logchange.hofund.connection.spring.datasource.h2;
+
+import dev.logchange.hofund.connection.spring.datasource.DatasourceConnection;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.sql.DataSource;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.util.Locale;
+
+@Slf4j
+public class H2Connection extends DatasourceConnection {
+
+    private static final String TEST_QUERY = "SELECT 1";
+
+    private String target;
+    private String url;
+    private String dbVendor;
+
+    public H2Connection(DatabaseMetaData metaData, DataSource dataSource) {
+        super(dataSource, TEST_QUERY);
+        try {
+            this.url = metaData.getURL();
+            int slashIndex = url.lastIndexOf('/');
+            int to = url.length();
+            if (url.lastIndexOf("?") != -1) {
+                to = url.lastIndexOf("?");
+            }
+            this.target = url.substring(slashIndex + 1, to).toLowerCase(Locale.ROOT);
+            this.dbVendor = metaData.getDatabaseProductName();
+            log.info("H2 info: target: {}, url: {}, dbVendor: {}", target, url, dbVendor);
+        } catch (SQLException e) {
+            log.warn("Error getting db information", e);
+            this.target = "ERROR";
+            this.url = "ERROR";
+            this.dbVendor = "ERROR";
+        }
+    }
+
+    @Override
+    protected String getTarget() {
+        return target;
+    }
+
+    @Override
+    protected String getUrl() {
+        return url;
+    }
+
+    @Override
+    protected String getDbVendor() {
+        return dbVendor;
+    }
+
+}

--- a/hofund-spring/src/main/java/dev/logchange/hofund/connection/spring/datasource/h2/H2Connection.java
+++ b/hofund-spring/src/main/java/dev/logchange/hofund/connection/spring/datasource/h2/H2Connection.java
@@ -21,14 +21,9 @@ public class H2Connection extends DatasourceConnection {
         super(dataSource, TEST_QUERY);
         try {
             this.url = metaData.getURL();
-            int slashIndex = url.lastIndexOf('/');
-            int to = url.length();
-            if (url.lastIndexOf("?") != -1) {
-                to = url.lastIndexOf("?");
-            }
-            this.target = url.substring(slashIndex + 1, to).toLowerCase(Locale.ROOT);
+            int colonIndex = url.lastIndexOf(':');
+            this.target = url.substring(colonIndex + 1).toLowerCase(Locale.ROOT);
             this.dbVendor = metaData.getDatabaseProductName();
-            log.info("H2 info: target: {}, url: {}, dbVendor: {}", target, url, dbVendor);
         } catch (SQLException e) {
             log.warn("Error getting db information", e);
             this.target = "ERROR";

--- a/hofund-spring/src/test/java/dev/logchange/hofund/connection/spring/datasource/h2/H2ConnectionTest.java
+++ b/hofund-spring/src/test/java/dev/logchange/hofund/connection/spring/datasource/h2/H2ConnectionTest.java
@@ -1,0 +1,42 @@
+package dev.logchange.hofund.connection.spring.datasource.h2;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.sql.DataSource;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class H2ConnectionTest {
+
+    @Mock
+    private DatabaseMetaData databaseMetaData;
+
+    @Mock
+    private DataSource dataSource;
+
+
+    @Test
+    void givenConnectionUrl_whenGetTarget_databaseNameReturned() throws SQLException {
+        //given:
+        String url = "spring.datasource.url=jdbc:h2:mem:17ebc6e8-e833-4157-b8e2-35f113eb404a";
+        String productName = "H2";
+        when(databaseMetaData.getURL()).thenReturn(url);
+        when(databaseMetaData.getDatabaseProductName()).thenReturn(productName);
+
+        //when:
+        H2Connection h2Connection = new H2Connection(databaseMetaData, dataSource);
+        String resultTarget = h2Connection.getTarget();
+        String resultVendor = h2Connection.getDbVendor();
+
+        //then:
+        assertThat(resultTarget).isEqualTo("17ebc6e8-e833-4157-b8e2-35f113eb404a");
+        assertThat(resultVendor).isEqualTo(productName);
+    }
+}


### PR DESCRIPTION
## Reason

To remove warnings from tests:
```
2024-11-23T19:45:29.121+01:00  WARN 9500 --- [HofundTest] [           main] d.l.h.c.s.d.DataSourceConnectionFactory  : Currently there is no support for DataSource: H2 please create issue at: https://github.com/logchange/hofund
2024-11-23T19:45:29.130+01:00  WARN 9500 --- [HofundTest] [           main] d.l.h.c.s.d.DataSourceConnectionFactory  : Currently there is no support for DataSource: H2 please create issue at: https://github.com/logchange/hofund
2024-11-23T19:45:29.133+01:00  WARN 9500 --- [HofundTest] [           main] d.l.h.c.s.d.DataSourceConnectionFactory  : Currently there is no support for DataSource: H2 please create issue at: https://github.com/logchange/hofund
```

## Result
```
2024-11-23T20:18:53.214+01:00  INFO 11948 --- [HofundTest] [           main] p.w.h.PrintHofundConnectionsTabel        : 
+----------+--------------------------------------+--------+--------------------------------------------------+
| TYPE     | NAME                                 | STATUS | URL                                              |
+----------+--------------------------------------+--------+--------------------------------------------------+
| HTTP     | google                               | UP     | https://www.google.com/                          |
| DATABASE | 3b53d4d7-2ea0-42dd-8fe9-425c21214032 | UP     | jdbc:h2:mem:3b53d4d7-2ea0-42dd-8fe9-425c21214032 |
+----------+--------------------------------------+--------+--------------------------------------------------+
```

```
# HELP hofund_connection Current status of given connection
# TYPE hofund_connection gauge
hofund_connection{db_vendor="H2",id="hofundtest-3b53d4d7-2ea0-42dd-8fe9-425c21214032_database",source="hofundtest",target="3b53d4d7-2ea0-42dd-8fe9-425c21214032_database",type="database"} 1.0
# HELP hofund_edge Information about hofund edge, value is always 1.0, to check status use hofund_connection
# TYPE hofund_edge gauge
hofund_edge{db_vendor="H2",id="hofundtest-3b53d4d7-2ea0-42dd-8fe9-425c21214032_database",source="hofundtest",target="3b53d4d7-2ea0-42dd-8fe9-425c21214032_database",type="database"} 1.0
```