### PR TITLE
Add queue connection support and improve metric binding resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,45 @@ If you want to use f.e `POST` method, you can use `new SimpleHofundHttpConnectio
 If you don't want to test connection in some conditions, you can use `new SimpleHofundHttpConnection("abc", "some_url", CheckingStatus.INACTIVE)` or override `getCheckingStatus()`.
 You can also disable connection checks for specific targets using environment variables. Set environment variable named `HOFUND_CONNECTION_<TARGET>_DISABLED` (where `<TARGET>` is the uppercase value of the target name) is set to either `true` (case-insensitive) or `1`. For example, to disable connection checks for a target named "payment-api", you would set the environment variable `HOFUND_CONNECTION_PAYMENT_API_DISABLED=true`.
 
+#### Queue, topic and broker connections
+
+Hofund does not depend on any messaging client, so a queue connection is described by a probe you supply:
+returning normally means UP, throwing anything means DOWN. Use `SimpleHofundQueueConnection` or extend
+`AbstractHofundBasicQueueConnection`. It works with any client — `javax.jms`, `jakarta.jms`, a Kafka bootstrap
+socket — because hofund never sees it.
+
+```java
+import dev.logchange.hofund.connection.SimpleHofundQueueConnection;
+import jakarta.jms.Connection;
+import jakarta.jms.ConnectionFactory;
+
+@Configuration
+public class QueueConnectionConfiguration {
+
+    @Bean
+    public SimpleHofundQueueConnection brokerConnection(ConnectionFactory probeConnectionFactory) {
+        return new SimpleHofundQueueConnection("broker", "amqp://broker.example.com:5672", () -> {
+            try (Connection connection = probeConnectionFactory.createConnection()) {
+                connection.start();
+            }
+        });
+    }
+}
+```
+
+Give the probe a connection factory of its own, without caching or pooling: a shared or cached connection keeps
+reporting UP long after the broker went down. The probe runs on the thread that scrapes the metric, so keep its
+timeout short (hofund's HTTP probes default to 1 s) and never let it touch production traffic — a consumer
+created on a real destination becomes a competing consumer and can take a real message.
+
+`CheckingStatus.INACTIVE` and `HOFUND_CONNECTION_<TARGET>_DISABLED` work here as they do for HTTP, and mean
+"not monitored". A target that is monitored but misconfigured belongs in DOWN, not INACTIVE.
+
+The description is empty by default, which for `Type.QUEUE` and `Type.DATABASE` matters: hofund builds the
+`target` metric label out of the target name, the type and the description, so `new
+SimpleHofundQueueConnection("broker", url, probe)` yields the label `broker_queue`, and passing a description
+makes it part of the label.
+
 ### 5. Manually creating HofundConnection
 
 If you need to create a HofundConnection manually, you must define a ConnectionFunction that will query the service you're interested in. The ConnectionFunction interface has a single method `getConnection()` that returns a HofundConnectionResult object.

--- a/changelog/unreleased/null-connection-no-longer-breaks-metrics.yml
+++ b/changelog/unreleased/null-connection-no-longer-breaks-metrics.yml
@@ -1,0 +1,9 @@
+# This file is used by logchange tool to generate CHANGELOG.md 🌳 🪓 => 🪵 
+# Visit https://github.com/logchange/logchange and leave a star 🌟 
+# More info about configuration you can find https://github.com/logchange/logchange#yaml-format ⬅️⬅ ️
+title: "A `HofundConnectionsProvider` returning `null`, or a list containing `null`, no longer breaks metric binding. Such an entry used to reach the meters and fail the whole binding with a `NullPointerException`, taking every other connection down with it; it is now skipped and logged."
+authors:
+  - name: Peter Zmilczak
+    nick: marwin1991
+    url: https://github.com/marwin1991
+type: fixed #[added/changed/deprecated/removed/fixed/security/other]

--- a/changelog/unreleased/null-connection-no-longer-breaks-metrics.yml
+++ b/changelog/unreleased/null-connection-no-longer-breaks-metrics.yml
@@ -7,3 +7,5 @@ authors:
     nick: marwin1991
     url: https://github.com/marwin1991
 type: fixed #[added/changed/deprecated/removed/fixed/security/other]
+merge_requests:
+  - 175

--- a/changelog/unreleased/queue-connections.yml
+++ b/changelog/unreleased/queue-connections.yml
@@ -7,3 +7,5 @@ authors:
     nick: marwin1991
     url: https://github.com/marwin1991
 type: added #[added/changed/deprecated/removed/fixed/security/other]
+merge_requests:
+  - 175

--- a/changelog/unreleased/queue-connections.yml
+++ b/changelog/unreleased/queue-connections.yml
@@ -1,0 +1,9 @@
+# This file is used by logchange tool to generate CHANGELOG.md 🌳 🪓 => 🪵 
+# Visit https://github.com/logchange/logchange and leave a star 🌟 
+# More info about configuration you can find https://github.com/logchange/logchange#yaml-format ⬅️⬅ ️
+title: "Introduced `SimpleHofundQueueConnection` and `AbstractHofundBasicQueueConnection` for testing queue, topic and message broker connections. Hofund stays free of any messaging client: the application supplies a `QueueProbe`, hofund maps it to UP/DOWN, handles `CheckingStatus`, the `HOFUND_CONNECTION_<TARGET>_DISABLED` environment variable and the logging."
+authors:
+  - name: Peter Zmilczak
+    nick: marwin1991
+    url: https://github.com/marwin1991
+type: added #[added/changed/deprecated/removed/fixed/security/other]

--- a/hofund-core/pom.xml
+++ b/hofund-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.logchange.hofund</groupId>
         <artifactId>hofund</artifactId>
-        <version>3.0.2-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>hofund-core</artifactId>

--- a/hofund-core/src/main/java/dev/logchange/hofund/connection/AbstractHofundBasicHttpConnection.java
+++ b/hofund-core/src/main/java/dev/logchange/hofund/connection/AbstractHofundBasicHttpConnection.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static dev.logchange.hofund.connection.HofundConnection.getEnvVarName;
 import static dev.logchange.hofund.connection.HofundConnectionResult.NOT_APPLICABLE;
 import static dev.logchange.hofund.connection.HofundConnectionResult.UNKNOWN;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -192,16 +191,6 @@ public abstract class AbstractHofundBasicHttpConnection {
      *         {@code false} otherwise
      */
     protected boolean isCheckingStatusInactiveByEnvs() {
-        String target = getTarget();
-        String envVarName = getEnvVarName(target);
-
-        String envVarValue = envProvider.getEnv(envVarName);
-
-        if ("true".equalsIgnoreCase(envVarValue) || "1".equals(envVarValue)) {
-            log.info("Connection check for target '{}' is disabled by environment variable '{}' with value '{}'", target, envVarName, envVarValue);
-            return true;
-        }
-
-        return false;
+        return CheckingStatusEnvs.isInactiveByEnvs(envProvider, getTarget());
     }
 }

--- a/hofund-core/src/main/java/dev/logchange/hofund/connection/AbstractHofundBasicQueueConnection.java
+++ b/hofund-core/src/main/java/dev/logchange/hofund/connection/AbstractHofundBasicQueueConnection.java
@@ -1,0 +1,141 @@
+package dev.logchange.hofund.connection;
+
+import dev.logchange.hofund.EnvProvider;
+import org.slf4j.Logger;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Base class for a {@link Type#QUEUE} connection check: a queue, a topic or a whole message broker.
+ * <p>
+ * Hofund brings no messaging client of its own, so the only thing a subclass has to provide is
+ * {@link #probe()} — returning normally reports UP, throwing anything reports DOWN. Everything around it, the
+ * status mapping, the {@link CheckingStatus} handling, the {@code HOFUND_CONNECTION_<TARGET>_DISABLED}
+ * environment variable and the logging, is handled here, so it stays identical across applications.
+ * <p>
+ * The description is empty by default. For {@link Type#QUEUE} and {@link Type#DATABASE} the description is
+ * part of the {@code target} metric label, so a value set here changes the label a dashboard matches on.
+ *
+ * @see SimpleHofundQueueConnection
+ */
+public abstract class AbstractHofundBasicQueueConnection {
+
+    private static final Logger log = getLogger(AbstractHofundBasicQueueConnection.class);
+
+    private final EnvProvider envProvider;
+
+    protected AbstractHofundBasicQueueConnection() {
+        this(new EnvProvider.SystemEnvProvider());
+    }
+
+    protected AbstractHofundBasicQueueConnection(EnvProvider envProvider) {
+        this.envProvider = envProvider;
+    }
+
+    /**
+     * Name of the queue, topic or broker that the application connects to f.e. amqp_broker.
+     *
+     * @return Name of the target
+     */
+    protected abstract String getTarget();
+
+    /**
+     * @return Address of the queue, topic or broker, f.e. {@code amqp://broker.example.com:5672}
+     */
+    protected abstract String getUrl();
+
+    /**
+     * Checks that the target is reachable. Returning normally reports UP, any exception reports DOWN.
+     *
+     * @throws Exception when the target cannot be reached
+     */
+    protected abstract void probe() throws Exception;
+
+    /**
+     * @return Description of the connection f.e. AMQP message broker. Beware: for {@link Type#QUEUE} the
+     * description becomes part of the {@code target} metric label.
+     */
+    protected String getDescription() {
+        return "";
+    }
+
+    /**
+     * Available icons:
+     * <a href="https://developers.grafana.com/ui/latest/index.html?path=/story/iconography-icon--icons-overview--icons-overview">Grafana BuiltIn Icons</a>
+     *
+     * @return Icon of the connection
+     */
+    protected String getIcon() {
+        return "";
+    }
+
+    /**
+     * If your connection can be disabled f.e. by a feature toggle, override this method. An unmonitored
+     * connection reports INACTIVE, which is not the same as DOWN: a misconfigured target that is supposed to
+     * be monitored should stay DOWN.
+     *
+     * @return checking status - informs if the connection check is active
+     */
+    protected CheckingStatus getCheckingStatus() {
+        return CheckingStatus.ACTIVE;
+    }
+
+    public HofundConnection toHofundConnection() {
+        HofundConnection hofundConnection = new HofundConnection(
+                getTarget(),
+                getUrl(),
+                Type.QUEUE,
+                new AtomicReference<>(testConnection()),
+                getDescription()
+        );
+        hofundConnection.setIcon(getIcon());
+        return hofundConnection;
+    }
+
+    private ConnectionFunction testConnection() {
+        return () -> {
+            if (getCheckingStatus() == CheckingStatus.INACTIVE) {
+                log.debug("Skipping checking connection to: {} due to inactive status checking", getTarget());
+                return HofundConnectionResult.queue(Status.INACTIVE);
+            }
+
+            if (isCheckingStatusInactiveByEnvs()) {
+                log.debug("Skipping checking connection to: {} due to disabling it in system envs", getTarget());
+                return HofundConnectionResult.queue(Status.INACTIVE);
+            }
+
+            try {
+                log.debug("Testing queue connection to: {} url: {}", getTarget(), getUrl());
+                probe();
+                return HofundConnectionResult.queue(Status.UP);
+            } catch (Exception e) {
+                log.warn("Error testing connection to: {} url: {} errorType: {} error: {}",
+                        getTarget(), getUrl(), e.getClass().getSimpleName(), e.getMessage());
+                log.debug("Exception: ", e);
+                return HofundConnectionResult.queue(Status.DOWN);
+            }
+        };
+    }
+
+    /**
+     * Checks if the connection status should be set to inactive based on environment variables.
+     * This method allows disabling connection checks for specific targets using environment variables.
+     *
+     * <p>The environment variable name is constructed as: {@code HOFUND_CONNECTION_<TARGET>_DISABLED}
+     * where {@code <TARGET>} is the uppercase value returned by {@link #getTarget()}.
+     *
+     * <p>The connection check will be disabled if the environment variable value is either:
+     * <ul>
+     *   <li>"true" (case-insensitive)</li>
+     *   <li>"1"</li>
+     * </ul>
+     *
+     * @return {@code true} if the connection check should be disabled based on environment variables,
+     *         {@code false} otherwise
+     */
+    protected boolean isCheckingStatusInactiveByEnvs() {
+        return CheckingStatusEnvs.isInactiveByEnvs(envProvider, getTarget());
+    }
+}

--- a/hofund-core/src/main/java/dev/logchange/hofund/connection/CheckingStatusEnvs.java
+++ b/hofund-core/src/main/java/dev/logchange/hofund/connection/CheckingStatusEnvs.java
@@ -1,0 +1,31 @@
+package dev.logchange.hofund.connection;
+
+import dev.logchange.hofund.EnvProvider;
+import org.slf4j.Logger;
+
+import static dev.logchange.hofund.connection.HofundConnection.getEnvVarName;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Resolves the {@code HOFUND_CONNECTION_<TARGET>_DISABLED} environment variable, shared by every connection
+ * type that supports switching its check off.
+ */
+final class CheckingStatusEnvs {
+
+    private static final Logger log = getLogger(CheckingStatusEnvs.class);
+
+    private CheckingStatusEnvs() {
+    }
+
+    static boolean isInactiveByEnvs(EnvProvider envProvider, String target) {
+        String envVarName = getEnvVarName(target);
+        String envVarValue = envProvider.getEnv(envVarName);
+
+        if ("true".equalsIgnoreCase(envVarValue) || "1".equals(envVarValue)) {
+            log.info("Connection check for target '{}' is disabled by environment variable '{}' with value '{}'", target, envVarName, envVarValue);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/hofund-core/src/main/java/dev/logchange/hofund/connection/HofundConnectionMeter.java
+++ b/hofund-core/src/main/java/dev/logchange/hofund/connection/HofundConnectionMeter.java
@@ -5,9 +5,7 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
 
-import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class HofundConnectionMeter implements MeterBinder {
 
@@ -19,10 +17,7 @@ public class HofundConnectionMeter implements MeterBinder {
 
     public HofundConnectionMeter(HofundInfoProvider infoProvider, List<HofundConnectionsProvider> connectionsProviders) {
         this.infoProvider = infoProvider;
-        this.connections = connectionsProviders.stream()
-                .map(HofundConnectionsProvider::getConnections)
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList());
+        this.connections = HofundConnections.from(connectionsProviders);
     }
 
 

--- a/hofund-core/src/main/java/dev/logchange/hofund/connection/HofundConnectionResult.java
+++ b/hofund-core/src/main/java/dev/logchange/hofund/connection/HofundConnectionResult.java
@@ -28,6 +28,10 @@ public class HofundConnectionResult {
         return new HofundConnectionResult(status, NOT_APPLICABLE);
     }
 
+    public static HofundConnectionResult queue(Status status) {
+        return new HofundConnectionResult(status, NOT_APPLICABLE);
+    }
+
     public static HofundConnectionResult http(Status status, String version) {
         return new HofundConnectionResult(status, version);
     }

--- a/hofund-core/src/main/java/dev/logchange/hofund/connection/HofundConnections.java
+++ b/hofund-core/src/main/java/dev/logchange/hofund/connection/HofundConnections.java
@@ -1,0 +1,55 @@
+package dev.logchange.hofund.connection;
+
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Collects the connections of every provider into one list, skipping what would later break metric binding.
+ * <p>
+ * A provider is free to return {@code null} or a list containing {@code null} — f.e.
+ * {@link AbstractHofundBasicHttpConnection#toHofundConnection()} returns {@code null} when the connection
+ * cannot be created. Such an entry used to reach the meters and fail the whole binding with a
+ * {@link NullPointerException}, taking every other connection down with it, so it is dropped here and logged.
+ */
+public final class HofundConnections {
+
+    private static final Logger log = getLogger(HofundConnections.class);
+
+    private HofundConnections() {
+    }
+
+    public static List<HofundConnection> from(List<HofundConnectionsProvider> connectionsProviders) {
+        if (connectionsProviders == null || connectionsProviders.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<HofundConnection> result = new ArrayList<>();
+        for (HofundConnectionsProvider provider : connectionsProviders) {
+            if (provider == null) {
+                log.warn("Null connections provider, skipping");
+                continue;
+            }
+
+            List<HofundConnection> connections = provider.getConnections();
+            if (connections == null) {
+                log.warn("Connections provider {} returned null, skipping", provider.getClass().getName());
+                continue;
+            }
+
+            for (HofundConnection connection : connections) {
+                if (connection == null) {
+                    log.warn("Connections provider {} returned a null connection, skipping", provider.getClass().getName());
+                    continue;
+                }
+                result.add(connection);
+            }
+        }
+
+        return result;
+    }
+}

--- a/hofund-core/src/main/java/dev/logchange/hofund/connection/HofundConnectionsTable.java
+++ b/hofund-core/src/main/java/dev/logchange/hofund/connection/HofundConnectionsTable.java
@@ -20,14 +20,9 @@ public class HofundConnectionsTable {
 
     public HofundConnectionsTable(List<HofundConnectionsProvider> connectionsProviders) {
 
-        if (connectionsProviders == null || connectionsProviders.isEmpty()) {
-            this.connections = Collections.emptyList();
-        } else {
-            this.connections = connectionsProviders.stream()
-                    .flatMap(t -> t.getConnections().stream())
-                    .sorted((d1, d2) -> d2.getType().compareTo(d1.getType()))
-                    .collect(Collectors.toList());
-        }
+        this.connections = HofundConnections.from(connectionsProviders).stream()
+                .sorted((d1, d2) -> d2.getType().compareTo(d1.getType()))
+                .collect(Collectors.toList());
 
     }
 

--- a/hofund-core/src/main/java/dev/logchange/hofund/connection/QueueProbe.java
+++ b/hofund-core/src/main/java/dev/logchange/hofund/connection/QueueProbe.java
@@ -1,0 +1,20 @@
+package dev.logchange.hofund.connection;
+
+/**
+ * A single reachability check of a queue, topic or message broker.
+ * <p>
+ * Hofund does not depend on any messaging client, so the probe itself is supplied by the application: open a
+ * short-lived connection, browse a queue, connect a socket — whatever proves that the broker answers. Returning
+ * normally means the target is UP; any exception means DOWN.
+ * <p>
+ * The probe runs on the thread that scrapes the metric, so it should be as cheap as a connect and must never
+ * touch production traffic — a consumer created on a real destination becomes a competing consumer.
+ */
+@FunctionalInterface
+public interface QueueProbe {
+
+    /**
+     * @throws Exception when the target cannot be reached; the connection is then reported as DOWN
+     */
+    void probe() throws Exception;
+}

--- a/hofund-core/src/main/java/dev/logchange/hofund/connection/SimpleHofundQueueConnection.java
+++ b/hofund-core/src/main/java/dev/logchange/hofund/connection/SimpleHofundQueueConnection.java
@@ -1,0 +1,69 @@
+package dev.logchange.hofund.connection;
+
+/**
+ * Ready to use {@link Type#QUEUE} connection built from a target name, an address and a {@link QueueProbe}.
+ * <p>
+ * Extend {@link AbstractHofundBasicQueueConnection} instead when the address or the checking status have to be
+ * resolved on every scrape.
+ */
+public class SimpleHofundQueueConnection extends AbstractHofundBasicQueueConnection {
+
+    private final String target;
+    private final String url;
+    private final QueueProbe probe;
+    private final CheckingStatus checkingStatus;
+    private final String description;
+    private final String icon;
+
+    public SimpleHofundQueueConnection(String target, String url, QueueProbe probe) {
+        this(target, url, probe, CheckingStatus.ACTIVE, "", "");
+    }
+
+    public SimpleHofundQueueConnection(String target, String url, QueueProbe probe, String description) {
+        this(target, url, probe, CheckingStatus.ACTIVE, description, "");
+    }
+
+    public SimpleHofundQueueConnection(String target, String url, QueueProbe probe, CheckingStatus checkingStatus) {
+        this(target, url, probe, checkingStatus, "", "");
+    }
+
+    public SimpleHofundQueueConnection(String target, String url, QueueProbe probe, CheckingStatus checkingStatus,
+                                       String description, String icon) {
+        this.target = target;
+        this.url = url;
+        this.probe = probe;
+        this.checkingStatus = checkingStatus;
+        this.description = description;
+        this.icon = icon;
+    }
+
+    @Override
+    protected String getTarget() {
+        return target;
+    }
+
+    @Override
+    protected String getUrl() {
+        return url;
+    }
+
+    @Override
+    protected void probe() throws Exception {
+        probe.probe();
+    }
+
+    @Override
+    protected String getDescription() {
+        return description;
+    }
+
+    @Override
+    protected String getIcon() {
+        return icon;
+    }
+
+    @Override
+    protected CheckingStatus getCheckingStatus() {
+        return checkingStatus;
+    }
+}

--- a/hofund-core/src/main/java/dev/logchange/hofund/graph/edge/HofundEdgeMeter.java
+++ b/hofund-core/src/main/java/dev/logchange/hofund/graph/edge/HofundEdgeMeter.java
@@ -1,17 +1,16 @@
 package dev.logchange.hofund.graph.edge;
 
 import dev.logchange.hofund.connection.HofundConnection;
+import dev.logchange.hofund.connection.HofundConnections;
 import dev.logchange.hofund.connection.HofundConnectionsProvider;
 import dev.logchange.hofund.info.HofundInfoProvider;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
 
-import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 /**
  * <a href="https://grafana.com/docs/grafana/latest/visualizations/node-graph/#node-parameters">Grafana Node Graph</a>
@@ -27,10 +26,7 @@ public class HofundEdgeMeter implements MeterBinder {
 
     public HofundEdgeMeter(HofundInfoProvider infoProvider, List<HofundConnectionsProvider> connectionsProviders) {
         this.infoProvider = infoProvider;
-        this.connections = connectionsProviders.stream()
-                .map(HofundConnectionsProvider::getConnections)
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList());
+        this.connections = HofundConnections.from(connectionsProviders);
         this.atomicInteger = new AtomicInteger(1);
 
         checkIdCollision();

--- a/hofund-core/src/main/java/dev/logchange/hofund/graph/node/HofundNodeMeter.java
+++ b/hofund-core/src/main/java/dev/logchange/hofund/graph/node/HofundNodeMeter.java
@@ -1,6 +1,7 @@
 package dev.logchange.hofund.graph.node;
 
 import dev.logchange.hofund.connection.HofundConnection;
+import dev.logchange.hofund.connection.HofundConnections;
 import dev.logchange.hofund.connection.HofundConnectionsProvider;
 import dev.logchange.hofund.info.HofundInfoProvider;
 import io.micrometer.core.instrument.Gauge;
@@ -8,12 +9,10 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.MeterBinder;
 
-import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 /**
  * <a href="https://grafana.com/docs/grafana/latest/visualizations/node-graph/#node-parameters">Grafana Node Graph</a>
@@ -29,10 +28,7 @@ public class HofundNodeMeter implements MeterBinder {
 
     public HofundNodeMeter(HofundInfoProvider infoProvider, List<HofundConnectionsProvider> connectionsProviders) {
         this.infoProvider = infoProvider;
-        this.connections = connectionsProviders.stream()
-                .map(HofundConnectionsProvider::getConnections)
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList());
+        this.connections = HofundConnections.from(connectionsProviders);
         this.atomicInteger = new AtomicInteger(1);
 
         checkIdCollision();

--- a/hofund-core/src/test/java/dev/logchange/hofund/connection/AbstractHofundBasicQueueConnectionTest.java
+++ b/hofund-core/src/test/java/dev/logchange/hofund/connection/AbstractHofundBasicQueueConnectionTest.java
@@ -1,0 +1,79 @@
+package dev.logchange.hofund.connection;
+
+import dev.logchange.hofund.EnvProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AbstractHofundBasicQueueConnectionTest {
+
+    private static class MockEnvProvider implements EnvProvider {
+
+        private final String returnValue;
+
+        MockEnvProvider(String returnValue) {
+            this.returnValue = returnValue;
+        }
+
+        @Override
+        public String getEnv(String name) {
+            return returnValue;
+        }
+    }
+
+    private static class TestConnection extends AbstractHofundBasicQueueConnection {
+
+        private final AtomicInteger probeCalls = new AtomicInteger();
+
+        TestConnection(EnvProvider envProvider) {
+            super(envProvider);
+        }
+
+        @Override
+        protected String getTarget() {
+            return "amqp_broker";
+        }
+
+        @Override
+        protected String getUrl() {
+            return "amqp://broker.example.com:5672";
+        }
+
+        @Override
+        protected void probe() {
+            probeCalls.incrementAndGet();
+        }
+    }
+
+    @Test
+    void shouldBeInactiveAndNotProbeWhenDisabledByEnvVariable() {
+        // given:
+        TestConnection connection = new TestConnection(new MockEnvProvider("true"));
+
+        // when:
+        Status status = statusOf(connection);
+
+        // then:
+        assertEquals(Status.INACTIVE, status);
+        assertEquals(0, connection.probeCalls.get());
+    }
+
+    @Test
+    void shouldProbeWhenEnvVariableIsNotSet() {
+        // given:
+        TestConnection connection = new TestConnection(new MockEnvProvider(null));
+
+        // when:
+        Status status = statusOf(connection);
+
+        // then:
+        assertEquals(Status.UP, status);
+        assertEquals(1, connection.probeCalls.get());
+    }
+
+    private static Status statusOf(TestConnection connection) {
+        return connection.toHofundConnection().getFun().get().getConnection().getStatus();
+    }
+}

--- a/hofund-core/src/test/java/dev/logchange/hofund/connection/HofundConnectionsTest.java
+++ b/hofund-core/src/test/java/dev/logchange/hofund/connection/HofundConnectionsTest.java
@@ -1,0 +1,76 @@
+package dev.logchange.hofund.connection;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HofundConnectionsTest {
+
+    @Test
+    void shouldReturnEmptyListForNoProviders() {
+        assertTrue(HofundConnections.from(null).isEmpty());
+        assertTrue(HofundConnections.from(Collections.emptyList()).isEmpty());
+    }
+
+    @Test
+    void shouldSkipProviderReturningNull() {
+        // given:
+        List<HofundConnectionsProvider> providers = Arrays.asList(() -> null, provider(connection("target1")));
+
+        // when:
+        List<HofundConnection> result = HofundConnections.from(providers);
+
+        // then:
+        assertEquals(1, result.size());
+        assertEquals("target1", result.get(0).getTarget());
+    }
+
+    @Test
+    void shouldSkipNullConnectionInsideProviderList() {
+        // given:
+        List<HofundConnection> withNull = new ArrayList<>();
+        withNull.add(null);
+        withNull.add(connection("target2"));
+
+        // when:
+        List<HofundConnection> result = HofundConnections.from(Collections.singletonList(() -> withNull));
+
+        // then:
+        assertEquals(1, result.size());
+        assertEquals("target2", result.get(0).getTarget());
+    }
+
+    @Test
+    void shouldKeepEveryConnectionOfEveryProvider() {
+        // given:
+        List<HofundConnectionsProvider> providers =
+                Arrays.asList(provider(connection("target1")), provider(connection("target2")));
+
+        // when:
+        List<HofundConnection> result = HofundConnections.from(providers);
+
+        // then:
+        assertEquals(2, result.size());
+    }
+
+    private static HofundConnectionsProvider provider(HofundConnection connection) {
+        return () -> Collections.singletonList(connection);
+    }
+
+    private static HofundConnection connection(String target) {
+        return new HofundConnection(
+                target,
+                "fake",
+                Type.QUEUE,
+                new AtomicReference<>(() -> HofundConnectionResult.queue(Status.UP)),
+                ""
+        );
+    }
+}

--- a/hofund-core/src/test/java/dev/logchange/hofund/connection/HofundConnectionsTest.java
+++ b/hofund-core/src/test/java/dev/logchange/hofund/connection/HofundConnectionsTest.java
@@ -20,6 +20,19 @@ class HofundConnectionsTest {
     }
 
     @Test
+    void shouldSkipNullProvider() {
+        // given:
+        List<HofundConnectionsProvider> providers = Arrays.asList(null, provider(connection("target1")));
+
+        // when:
+        List<HofundConnection> result = HofundConnections.from(providers);
+
+        // then:
+        assertEquals(1, result.size());
+        assertEquals("target1", result.get(0).getTarget());
+    }
+
+    @Test
     void shouldSkipProviderReturningNull() {
         // given:
         List<HofundConnectionsProvider> providers = Arrays.asList(() -> null, provider(connection("target1")));

--- a/hofund-core/src/test/java/dev/logchange/hofund/connection/SimpleHofundQueueConnectionTest.java
+++ b/hofund-core/src/test/java/dev/logchange/hofund/connection/SimpleHofundQueueConnectionTest.java
@@ -1,0 +1,103 @@
+package dev.logchange.hofund.connection;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SimpleHofundQueueConnectionTest {
+
+    private static final String TARGET = "amqp_broker";
+    private static final String URL = "amqp://broker.example.com:5672";
+
+    @Test
+    void shouldExposeQueueConnectionWithoutDescriptionByDefault() {
+        // given:
+        SimpleHofundQueueConnection connection = new SimpleHofundQueueConnection(TARGET, URL, () -> {
+        });
+
+        // when:
+        HofundConnection result = connection.toHofundConnection();
+
+        // then:
+        assertEquals(TARGET, result.getTarget());
+        assertEquals(URL, result.getUrl());
+        assertEquals(Type.QUEUE, result.getType());
+        assertEquals("", result.getDescription());
+        assertEquals("amqp_broker_queue", result.toTargetTag());
+    }
+
+    @Test
+    void shouldIncludeDescriptionInTargetTagWhenGiven() {
+        // given:
+        SimpleHofundQueueConnection connection =
+                new SimpleHofundQueueConnection(TARGET, URL, () -> {
+                }, "AMQP message broker");
+
+        // when:
+        HofundConnection result = connection.toHofundConnection();
+
+        // then:
+        assertEquals("amqp_broker_queue_amqp message broker", result.toTargetTag());
+    }
+
+    @Test
+    void shouldBeUpWhenProbeReturnsNormally() {
+        // given:
+        SimpleHofundQueueConnection connection = new SimpleHofundQueueConnection(TARGET, URL, () -> {
+        });
+
+        // when:
+        Status status = statusOf(connection);
+
+        // then:
+        assertEquals(Status.UP, status);
+    }
+
+    @Test
+    void shouldBeDownWhenProbeThrows() {
+        // given:
+        SimpleHofundQueueConnection connection = new SimpleHofundQueueConnection(TARGET, URL, () -> {
+            throw new IllegalStateException("broker down");
+        });
+
+        // when:
+        Status status = statusOf(connection);
+
+        // then:
+        assertEquals(Status.DOWN, status);
+    }
+
+    @Test
+    void shouldBeInactiveAndNotProbeWhenCheckingStatusIsInactive() {
+        // given:
+        AtomicInteger probeCalls = new AtomicInteger();
+        SimpleHofundQueueConnection connection = new SimpleHofundQueueConnection(TARGET, URL,
+                probeCalls::incrementAndGet, CheckingStatus.INACTIVE);
+
+        // when:
+        Status status = statusOf(connection);
+
+        // then:
+        assertEquals(Status.INACTIVE, status);
+        assertEquals(0, probeCalls.get());
+    }
+
+    @Test
+    void shouldReportNotApplicableVersion() {
+        // given:
+        SimpleHofundQueueConnection connection = new SimpleHofundQueueConnection(TARGET, URL, () -> {
+        });
+
+        // when:
+        HofundConnectionResult result = connection.toHofundConnection().getFun().get().getConnection();
+
+        // then:
+        assertEquals(HofundConnectionResult.NOT_APPLICABLE, result.getVersion().toString());
+    }
+
+    private static Status statusOf(SimpleHofundQueueConnection connection) {
+        return connection.toHofundConnection().getFun().get().getConnection().getStatus();
+    }
+}

--- a/hofund-spring-boot-autoconfigure/pom.xml
+++ b/hofund-spring-boot-autoconfigure/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.logchange.hofund</groupId>
         <artifactId>hofund</artifactId>
-        <version>3.0.2-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>hofund-spring-boot-autoconfigure</artifactId>

--- a/hofund-spring-boot-autoconfigure/src/main/java/dev/logchange/hofund/connection/springboot/autoconfigure/HofundConnectionAutoConfiguration.java
+++ b/hofund-spring-boot-autoconfigure/src/main/java/dev/logchange/hofund/connection/springboot/autoconfigure/HofundConnectionAutoConfiguration.java
@@ -1,10 +1,12 @@
 package dev.logchange.hofund.connection.springboot.autoconfigure;
 
 import dev.logchange.hofund.connection.AbstractHofundBasicHttpConnection;
+import dev.logchange.hofund.connection.AbstractHofundBasicQueueConnection;
 import dev.logchange.hofund.connection.HofundConnectionMeter;
 import dev.logchange.hofund.connection.HofundConnectionsProvider;
 import dev.logchange.hofund.connection.spring.datasource.DataSourceConnectionsProvider;
 import dev.logchange.hofund.connection.spring.http.HofundBasicHttpConnectionProvider;
+import dev.logchange.hofund.connection.spring.queue.HofundBasicQueueConnectionProvider;
 import dev.logchange.hofund.info.HofundInfoProvider;
 import dev.logchange.hofund.info.springboot.autoconfigure.HofundInfoAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -40,5 +42,11 @@ public class HofundConnectionAutoConfiguration {
     @ConditionalOnMissingBean
     public HofundBasicHttpConnectionProvider httpBasicConnectionProvider(List<AbstractHofundBasicHttpConnection> hofundBasicHttpConnections) {
         return new HofundBasicHttpConnectionProvider(hofundBasicHttpConnections);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public HofundBasicQueueConnectionProvider queueBasicConnectionProvider(List<AbstractHofundBasicQueueConnection> hofundBasicQueueConnections) {
+        return new HofundBasicQueueConnectionProvider(hofundBasicQueueConnections);
     }
 }

--- a/hofund-spring-boot-e2e/pom.xml
+++ b/hofund-spring-boot-e2e/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hofund</artifactId>
         <groupId>dev.logchange.hofund</groupId>
-        <version>3.0.2-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>hofund-spring-boot-e2e</artifactId>

--- a/hofund-spring-boot-starter/pom.xml
+++ b/hofund-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hofund</artifactId>
         <groupId>dev.logchange.hofund</groupId>
-        <version>3.0.2-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>hofund-spring-boot-starter</artifactId>

--- a/hofund-spring/pom.xml
+++ b/hofund-spring/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.logchange.hofund</groupId>
         <artifactId>hofund</artifactId>
-        <version>3.0.2-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>hofund-spring</artifactId>

--- a/hofund-spring/src/main/java/dev/logchange/hofund/connection/spring/queue/HofundBasicQueueConnectionProvider.java
+++ b/hofund-spring/src/main/java/dev/logchange/hofund/connection/spring/queue/HofundBasicQueueConnectionProvider.java
@@ -1,0 +1,30 @@
+package dev.logchange.hofund.connection.spring.queue;
+
+import dev.logchange.hofund.connection.AbstractHofundBasicQueueConnection;
+import dev.logchange.hofund.connection.HofundConnection;
+import dev.logchange.hofund.connection.HofundConnectionsProvider;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class HofundBasicQueueConnectionProvider implements HofundConnectionsProvider {
+
+    private final List<HofundConnection> connections;
+
+    public HofundBasicQueueConnectionProvider(List<AbstractHofundBasicQueueConnection> connections) {
+        this.connections = connections.stream()
+                .map(AbstractHofundBasicQueueConnection::toHofundConnection)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<HofundConnection> getConnections() {
+        if (connections == null) {
+            return Collections.emptyList();
+        }
+        return connections;
+    }
+}

--- a/hofund-spring/src/main/java/dev/logchange/hofund/connection/spring/queue/HofundBasicQueueConnectionProvider.java
+++ b/hofund-spring/src/main/java/dev/logchange/hofund/connection/spring/queue/HofundBasicQueueConnectionProvider.java
@@ -4,7 +4,6 @@ import dev.logchange.hofund.connection.AbstractHofundBasicQueueConnection;
 import dev.logchange.hofund.connection.HofundConnection;
 import dev.logchange.hofund.connection.HofundConnectionsProvider;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -22,9 +21,6 @@ public class HofundBasicQueueConnectionProvider implements HofundConnectionsProv
 
     @Override
     public List<HofundConnection> getConnections() {
-        if (connections == null) {
-            return Collections.emptyList();
-        }
         return connections;
     }
 }

--- a/hofund-spring/src/test/java/dev/logchange/hofund/connection/spring/queue/HofundBasicQueueConnectionProviderTest.java
+++ b/hofund-spring/src/test/java/dev/logchange/hofund/connection/spring/queue/HofundBasicQueueConnectionProviderTest.java
@@ -1,0 +1,69 @@
+package dev.logchange.hofund.connection.spring.queue;
+
+import dev.logchange.hofund.connection.AbstractHofundBasicQueueConnection;
+import dev.logchange.hofund.connection.HofundConnection;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HofundBasicQueueConnectionProviderTest {
+
+    private static class TestConnection extends AbstractHofundBasicQueueConnection {
+
+        private final String target;
+
+        TestConnection(String target) {
+            this.target = target;
+        }
+
+        @Override
+        protected String getTarget() {
+            return target;
+        }
+
+        @Override
+        protected String getUrl() {
+            return "amqp://broker.example.com:5672";
+        }
+
+        @Override
+        protected void probe() {
+        }
+    }
+
+    private static class NullConnection extends TestConnection {
+
+        NullConnection() {
+            super("null_broker");
+        }
+
+        @Override
+        public HofundConnection toHofundConnection() {
+            return null;
+        }
+    }
+
+    @Test
+    void shouldReturnEmptyListForNoConnections() {
+        assertTrue(new HofundBasicQueueConnectionProvider(Collections.emptyList()).getConnections().isEmpty());
+    }
+
+    @Test
+    void shouldMapConnectionsAndSkipNullOnes() {
+        // given:
+        List<AbstractHofundBasicQueueConnection> connections =
+                Arrays.asList(new TestConnection("amqp_broker"), new NullConnection());
+
+        // when:
+        List<HofundConnection> result = new HofundBasicQueueConnectionProvider(connections).getConnections();
+
+        // then:
+        assertEquals(1, result.size());
+        assertEquals("amqp_broker", result.get(0).getTarget());
+    }
+}

--- a/hofund-test-reports/pom.xml
+++ b/hofund-test-reports/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hofund</artifactId>
         <groupId>dev.logchange.hofund</groupId>
-        <version>3.0.2-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>hofund-test-reports</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>dev.logchange.hofund</groupId>
     <artifactId>hofund</artifactId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>hofund</name>


### PR DESCRIPTION
- Introduced `SimpleHofundQueueConnection` and `AbstractHofundBasicQueueConnection` for handling queue, topic, and message broker connections.
- Prevented `null` connections from breaking metric binding by skipping and logging invalid entries.
- Updated `HofundEdgeMeter` and `HofundNodeMeter` to utilize the new `HofundConnections.from` utility.
- Added Spring support for queue connections with `HofundBasicQueueConnectionProvider`.
- Bumped project version to `3.1.0-SNAPSHOT`.